### PR TITLE
Problem page: fix parser error + enable scrolling

### DIFF
--- a/app/problems/[id]/page.tsx
+++ b/app/problems/[id]/page.tsx
@@ -268,9 +268,9 @@ export default function ProblemPage() {
 
   // Render
   return (
-    <div className="caffeine-theme h-screen w-full bg-background p-2 pt-0">
+    <div className="caffeine-theme min-h-screen w-full bg-background p-2 pt-0 overflow-y-auto">
       <style jsx global>{tabScrollStyles}</style>
-      <ResizablePanelGroup direction="horizontal" className="h-full">
+      <ResizablePanelGroup direction="horizontal" className="min-h-[700px]">
         {/* LEFT: Problem Description & history */}
         <ResizablePanel defaultSize={30} minSize={20} maxSize={40}>
           <ProblemDescriptionPanel


### PR DESCRIPTION
This PR contains both fixes:

- Fix parsing error on problem page by removing stray top-level async/try block in app/problems/[id]/page.tsx
- Make problem page scrollable by switching container to min-h-screen + overflow-y-auto and setting a min height on the ResizablePanelGroup